### PR TITLE
Fix Docker build and restore frontend styles

### DIFF
--- a/aplikacja_python/backend/Dockerfile
+++ b/aplikacja_python/backend/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/aplikacja_python/frontend/nginx.conf
+++ b/aplikacja_python/frontend/nginx.conf
@@ -1,0 +1,11 @@
+server {
+  listen 80;
+  server_name localhost;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri /index.html;
+  }
+}

--- a/aplikacja_python/frontend/src/main.tsx
+++ b/aplikacja_python/frontend/src/main.tsx
@@ -7,7 +7,7 @@ import { MonthProvider } from './contexts/month-context';
 import { ThemeProvider } from './contexts/theme-context';  // opcjonalnie
 
 import App from './App';
-//import './styles/index.css';  // import Tailwind CSS
+import './index.css';  // import Tailwind CSS
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+cd aplikacja_python
+./start.sh "$@"


### PR DESCRIPTION
## Summary
- add nginx config and backend Dockerfile for Docker builds
- restore Tailwind styles by importing index.css
- provide root start script to launch full stack

## Testing
- `npm --prefix aplikacja_python/frontend run build`
- `./start.sh` *(fails: Docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689099e97c7c832395490c3e5a6ee289