### PR TITLE
Fix database setup to create tables before seeding

### DIFF
--- a/aplikacja_python/init-db.sql
+++ b/aplikacja_python/init-db.sql
@@ -1,85 +1,84 @@
--- Create database if it doesn't exist
-SELECT 'CREATE DATABASE budget_db'
-WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'budget_db');
+-- Initialize budget database
 
--- Create user if it doesn't exist
-DO
-$do$
-BEGIN
-   IF NOT EXISTS (
-      SELECT FROM pg_catalog.pg_roles
-      WHERE  rolname = 'budget_user') THEN
-
-      CREATE ROLE budget_user LOGIN PASSWORD 'budget_password';
-   END IF;
-END
-$do$;
-
--- Grant privileges
-GRANT ALL PRIVILEGES ON DATABASE budget_db TO budget_user;
-
--- Connect to the budget database
+-- Connect to the budget database (created by POSTGRES_DB)
 \c budget_db;
 
 -- Enable UUID extension
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
--- Sample data (will be inserted only if tables are empty)
--- Categories
-INSERT INTO categories (id, name, color, budget) 
-SELECT 
-    uuid_generate_v4()::text,
-    'Żywność',
-    '#10B981',
-    1500.00
+-- Create tables if they do not exist
+CREATE TABLE IF NOT EXISTS categories (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name VARCHAR(255) NOT NULL,
+    color VARCHAR(7) NOT NULL,
+    budget DECIMAL(10,2) NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS incomes (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name VARCHAR(255) NOT NULL,
+    amount DECIMAL(10,2) NOT NULL,
+    frequency VARCHAR(50) NOT NULL,
+    date VARCHAR(10) NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS expenses (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    description VARCHAR(255) NOT NULL,
+    amount DECIMAL(10,2) NOT NULL,
+    category_id UUID NOT NULL,
+    date VARCHAR(10) NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS investments (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    symbol VARCHAR(20) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    type VARCHAR(50) NOT NULL,
+    quantity DECIMAL(15,8) NOT NULL,
+    purchase_price DECIMAL(10,2) NOT NULL,
+    current_price DECIMAL(10,2),
+    purchase_date VARCHAR(10) NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS savings_goals (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    title VARCHAR(255) NOT NULL,
+    target_amount DECIMAL(10,2) NOT NULL,
+    current_amount DECIMAL(10,2) NOT NULL DEFAULT 0,
+    target_date VARCHAR(10) NOT NULL,
+    category VARCHAR(100) NOT NULL,
+    color VARCHAR(7) NOT NULL,
+    is_completed BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Sample data (insert only if missing)
+INSERT INTO categories (id, name, color, budget)
+SELECT uuid_generate_v4(), 'Żywność', '#10B981', 1500.00
 WHERE NOT EXISTS (SELECT 1 FROM categories WHERE name = 'Żywność');
 
-INSERT INTO categories (id, name, color, budget) 
-SELECT 
-    uuid_generate_v4()::text,
-    'Transport',
-    '#3B82F6',
-    500.00
+INSERT INTO categories (id, name, color, budget)
+SELECT uuid_generate_v4(), 'Transport', '#3B82F6', 500.00
 WHERE NOT EXISTS (SELECT 1 FROM categories WHERE name = 'Transport');
 
-INSERT INTO categories (id, name, color, budget) 
-SELECT 
-    uuid_generate_v4()::text,
-    'Rozrywka',
-    '#8B5CF6',
-    300.00
+INSERT INTO categories (id, name, color, budget)
+SELECT uuid_generate_v4(), 'Rozrywka', '#8B5CF6', 300.00
 WHERE NOT EXISTS (SELECT 1 FROM categories WHERE name = 'Rozrywka');
 
--- Sample income
-INSERT INTO incomes (id, name, amount, frequency, date) 
-SELECT 
-    uuid_generate_v4()::text,
-    'Pensja',
-    5000.00,
-    'monthly',
-    CURRENT_DATE
+INSERT INTO incomes (id, name, amount, frequency, date)
+SELECT uuid_generate_v4(), 'Pensja', 5000.00, 'monthly', CURRENT_DATE::text
 WHERE NOT EXISTS (SELECT 1 FROM incomes WHERE name = 'Pensja');
 
--- Sample investment
-INSERT INTO investments (id, symbol, name, type, quantity, purchase_price, purchase_date) 
-SELECT 
-    uuid_generate_v4()::text,
-    'AAPL',
-    'Apple Inc.',
-    'stock',
-    10.00000000,
-    150.00,
-    CURRENT_DATE - INTERVAL '30 days'
+INSERT INTO investments (id, symbol, name, type, quantity, purchase_price, purchase_date)
+SELECT uuid_generate_v4(), 'AAPL', 'Apple Inc.', 'stock', 10.00000000, 150.00, (CURRENT_DATE - INTERVAL '30 days')::text
 WHERE NOT EXISTS (SELECT 1 FROM investments WHERE symbol = 'AAPL');
 
--- Sample savings goal
-INSERT INTO savings_goals (id, name, description, target_amount, current_amount, target_date, color) 
-SELECT 
-    uuid_generate_v4()::text,
-    'Wakacje',
-    'Oszczędności na letnie wakacje',
-    5000.00,
-    1200.00,
-    CURRENT_DATE + INTERVAL '6 months',
-    '#F59E0B'
-WHERE NOT EXISTS (SELECT 1 FROM savings_goals WHERE name = 'Wakacje');
+INSERT INTO savings_goals (id, title, target_amount, current_amount, target_date, category, color)
+SELECT uuid_generate_v4(), 'Wakacje', 5000.00, 1200.00, (CURRENT_DATE + INTERVAL '6 months')::text, 'Wypoczynek', '#F59E0B'
+WHERE NOT EXISTS (SELECT 1 FROM savings_goals WHERE title = 'Wakacje');
+


### PR DESCRIPTION
## Summary
- create required tables during database initialization
- seed default data only after tables are present

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68909c76e5ec8323978d1d791a82dda2