### PR TITLE
Fix frontend Nginx configuration and backend docs dependency

### DIFF
--- a/aplikacja_python/backend/requirements.txt
+++ b/aplikacja_python/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.104.1
+jinja2==3.1.3
 uvicorn[standard]==0.24.0
 sqlalchemy==2.0.23
 psycopg2-binary==2.9.9

--- a/aplikacja_python/frontend/Dockerfile
+++ b/aplikacja_python/frontend/Dockerfile
@@ -24,7 +24,8 @@ FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
 
 # Kopiuj własną konfigurację nginx (jeśli potrzebna, np. dla SPA history mode)
-COPY nginx.conf /etc/nginx/nginx.conf
+# Używamy katalogu conf.d, aby zachować domyślny nginx.conf
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 


### PR DESCRIPTION
## Summary
- fix frontend Dockerfile to place Nginx server config under `/etc/nginx/conf.d`
- add missing `jinja2` dependency so FastAPI docs render correctly

## Testing
- `npm run build` (frontend)
- `pip install -r aplikacja_python/backend/requirements.txt`
- `pytest`
- `docker build -t frontend-test aplikacja_python/frontend` *(fails: docker command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890a05dbcb08323a7e179d8afa8dbe5