### PR TITLE
Fix savings frontend to match FastAPI endpoints

### DIFF
--- a/aplikacja_python/frontend/src/types.ts
+++ b/aplikacja_python/frontend/src/types.ts
@@ -69,21 +69,19 @@ export interface InvestmentSale {
 
 // Savings goals
 export const insertSavingsGoalSchema = z.object({
-  name: z.string().min(1),
+  title: z.string().min(1),
   targetAmount: z.string().min(1),
-  targetDate: z.string().optional().nullable(),
+  targetDate: z.string().min(1),
   category: z.string().min(1),
   color: z.string().min(1),
-  description: z.string().optional().nullable(),
 });
 export type InsertSavingsGoal = z.infer<typeof insertSavingsGoalSchema>;
 export interface SavingsGoal {
   id: string;
-  name: string;
-  description?: string | null;
+  title: string;
   targetAmount: string;
   currentAmount: string;
-  targetDate?: string | null;
+  targetDate: string;
   category: string;
   color: string;
   isCompleted?: boolean;


### PR DESCRIPTION
## Summary
- align savings goal schema with FastAPI by renaming fields and requiring a target date
- update savings page to use new field names and correct add-savings endpoint

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890d33238a88323b7dfb7a69afad5ee